### PR TITLE
Fix launch baudrate

### DIFF
--- a/launch/lidar.launch
+++ b/launch/lidar.launch
@@ -1,7 +1,7 @@
 <launch>
   <node name="ydlidar_node"  pkg="ydlidar"  type="ydlidar_node" output="screen">
     <param name="port"         type="string" value="/dev/ydlidar"/>  
-    <param name="baudrate"     type="int"    value="115200"/>
+    <param name="baudrate"     type="int"    value="128000"/>
     <param name="frame_id"     type="string" value="laser_frame"/>
     <param name="angle_fixed"  type="bool"   value="true"/>
     <param name="intensities"  type="bool"   value="false"/>


### PR DESCRIPTION
修正依照預設教學啟動時會出現的錯誤：
[ERROR] [1516528584.194691125]: Error, cannot retrieve YDLIDAR health code: ffffffff
根據官方文件：http://eaibot.com/download 中的 YDLIDAR X4 数据手册.pdf
預設波特率應為128000
此錯誤到處都有，還請官方協助修正