### PR TITLE
Fix for the ROS LaserScan message time attributes

### DIFF
--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -131,8 +131,8 @@ int main(int argc, char * argv[]) {
             scan_msg.angle_min = scan.config.min_angle;
             scan_msg.angle_max = scan.config.max_angle;
             scan_msg.angle_increment = scan.config.ang_increment;
-            scan_msg.scan_time = scan.config.scan_time;
-            scan_msg.time_increment = scan.config.time_increment;
+            scan_msg.scan_time = scan.config.scan_time/1000000000.0;
+            scan_msg.time_increment = scan.config.time_increment/1000000000.0;
             scan_msg.range_min = scan.config.min_range;
             scan_msg.range_max = scan.config.max_range;
             

--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -131,8 +131,8 @@ int main(int argc, char * argv[]) {
             scan_msg.angle_min = scan.config.min_angle;
             scan_msg.angle_max = scan.config.max_angle;
             scan_msg.angle_increment = scan.config.ang_increment;
-            scan_msg.scan_time = scan.config.scan_time/1000000000.0;
-            scan_msg.time_increment = scan.config.time_increment/1000000000.0;
+            scan_msg.scan_time = scan.config.scan_time*1e-9;
+            scan_msg.time_increment = scan.config.time_increment*1e-9;
             scan_msg.range_min = scan.config.min_range;
             scan_msg.range_max = scan.config.max_range;
             


### PR DESCRIPTION
The standard ROS definition of the sensor_msgs/LaserScan.msg states the time_increment and scan_time fields to have a unit of seconds. The original ydlidar ros node, however, publishes these values in nanoseconds.