### PR TITLE
Fix incorrect time_increment and scan_time

### DIFF
--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -131,8 +131,8 @@ int main(int argc, char * argv[]) {
             scan_msg.angle_min = scan.config.min_angle;
             scan_msg.angle_max = scan.config.max_angle;
             scan_msg.angle_increment = scan.config.ang_increment;
-            scan_msg.scan_time = scan.config.scan_time;
-            scan_msg.time_increment = scan.config.time_increment;
+            scan_msg.scan_time = 1/_frequency;
+            scan_msg.time_increment = 1/((float)samp_rate*1000);
             scan_msg.range_min = scan.config.min_range;
             scan_msg.range_max = scan.config.max_range;
             


### PR DESCRIPTION
This bug affects rviz display and potentially all laser tools