### PR TITLE
Convert scan_time and time_increment from nanoseconds to seconds for ROS msgs

### DIFF
--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -131,8 +131,9 @@ int main(int argc, char * argv[]) {
             scan_msg.angle_min = scan.config.min_angle;
             scan_msg.angle_max = scan.config.max_angle;
             scan_msg.angle_increment = scan.config.ang_increment;
-            scan_msg.scan_time = scan.config.scan_time;
-            scan_msg.time_increment = scan.config.time_increment;
+            //convert scan_time and time_increment from nanoseconds to seconds for ROS msg
+            scan_msg.scan_time = scan.config.scan_time/1000000000ul;
+            scan_msg.time_increment = scan.config.time_increment/1000000000ul;
             scan_msg.range_min = scan.config.min_range;
             scan_msg.range_max = scan.config.max_range;
             


### PR DESCRIPTION
Fixes #31.
ROS msgs expect time_increment and scan_time in seconds (see [msg documentation](http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/LaserScan.html)). However, internally scan_time is computed from stamp measures in nanoseconds:
https://github.com/EAIBOT/ydlidar/blob/ceca2ce394a3851b17d9b55c71e4169d898b384d/sdk/src/CYdLidar.cpp#L136
https://github.com/EAIBOT/ydlidar/blob/ceca2ce394a3851b17d9b55c71e4169d898b384d/sdk/src/CYdLidar.cpp#L83-L84
https://github.com/EAIBOT/ydlidar/blob/ceca2ce394a3851b17d9b55c71e4169d898b384d/sdk/src/ydlidar_driver.cpp#L689
https://github.com/EAIBOT/ydlidar/blob/ceca2ce394a3851b17d9b55c71e4169d898b384d/sdk/src/ydlidar_driver.cpp#L683